### PR TITLE
Fix CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       # - image: circleci/postgres:9.4
 
     environment:
-      GO111MODULE: on
+      GO111MODULE: "on"
     #### TEMPLATE_NOTE: go expects specific checkout path representing url
     #### expecting it in the form of
     ####   /go/src/github.com/circleci/go-tool


### PR DESCRIPTION
It seems that yaml sees an unquoted `on` value as `true`.
Take a look if it would works.

Also, I wanted to ask you to turn on CI on PR branches.