### PR TITLE
Use int64 for ID properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ func main() {
                 return
         }
 
-        ev, err := c.FindEvent("123")
+        ev, err := c.FindEvent(123)
         if err != nil {
                 fmt.Printf("%s\n", err)
                 return

--- a/attachment.go
+++ b/attachment.go
@@ -1,7 +1,7 @@
 package garoon
 
 type Attachment struct {
-	ID          string `json:"id"`
+	ID          int64  `json:"id,string"`
 	Name        string `json:"name"`
 	ContentType string `json:"contentType"`
 	Size        string `json:"size"`

--- a/available_time_test.go
+++ b/available_time_test.go
@@ -24,7 +24,7 @@ func TestAvailableTimes(t *testing.T) {
 	c, err := NewClient("subdomain", "user", "password")
 
 	a := Attendee{}
-	a.ID = "940"
+	a.ID = 940
 	a.Type = "USER"
 
 	d := DateTimePeriod{}
@@ -32,7 +32,7 @@ func TestAvailableTimes(t *testing.T) {
 	d.End = time.Date(2019, 1, 6, 10, 30, 0, 0, time.Local)
 
 	f := Facility{}
-	f.ID = "45"
+	f.ID = 45
 
 	p := AvailableTimeParameter{}
 	p.TimeRanges = append(p.TimeRanges, d)

--- a/event.go
+++ b/event.go
@@ -33,7 +33,7 @@ type AdditionalItems struct {
 }
 
 type Event struct {
-	ID                       string                    `json:"id,omitempty"`
+	ID                       int64                     `json:"id,string,omitempty"`
 	Creator                  Creator                   `json:"creator,omitempty"`
 	CreatedAt                time.Time                 `json:"createdAt,omitempty"`
 	Updater                  Updater                   `json:"updater,omitempty"`
@@ -64,8 +64,8 @@ type Event struct {
 	RepeatID                 string                    `json:"repeatId,omitempty"`
 }
 
-func (c *Client) FindEvent(id string) (*Event, error) {
-	path := fmt.Sprintf("schedule/events/%s", id)
+func (c *Client) FindEvent(id int64) (*Event, error) {
+	path := fmt.Sprintf("schedule/events/%d", id)
 	var event Event
 	if err := c.fetchResource("GET", path, nil, &event); err != nil {
 		return nil, err
@@ -92,7 +92,7 @@ func (c *Client) CreateEvent(event *Event) (*Event, error) {
 }
 
 func (c *Client) UpdateEvent(event *Event) (*Event, error) {
-	path := fmt.Sprintf("schedule/events/%s", event.ID)
+	path := fmt.Sprintf("schedule/events/%d", event.ID)
 	var newEvent Event
 	if err := c.fetchResource("PATCH", path, event, &newEvent); err != nil {
 		return nil, err
@@ -100,8 +100,8 @@ func (c *Client) UpdateEvent(event *Event) (*Event, error) {
 	return &newEvent, nil
 }
 
-func (c *Client) DeleteEvent(id string) error {
-	path := fmt.Sprintf("schedule/events/%s", id)
+func (c *Client) DeleteEvent(id int64) error {
+	path := fmt.Sprintf("schedule/events/%d", id)
 	if err := c.fetchResource("DELETE", path, nil, nil); err != nil {
 		return err
 	}

--- a/event_test.go
+++ b/event_test.go
@@ -15,13 +15,13 @@ func TestFindEvent(t *testing.T) {
 
 	b, err := ioutil.ReadFile("testdata/event.json")
 	if err != nil {
-		t.Fatal()
+		t.Fatalf("Failed to read test data: %v", err)
 		return
 	}
 
 	var event Event
 	if err = json.Unmarshal(b, &event); err != nil {
-		t.Fatal()
+		t.Fatalf("Failed to unmarshal event data: %v", err)
 		return
 	}
 
@@ -43,7 +43,7 @@ func TestSearchEvents(t *testing.T) {
 
 	b, err := ioutil.ReadFile("testdata/events.json")
 	if err != nil {
-		t.Fatal()
+		t.Fatalf("Failed to read test data: %v", err)
 		return
 	}
 
@@ -67,13 +67,13 @@ func TestCreateEvent(t *testing.T) {
 
 	b, err := ioutil.ReadFile("testdata/event.json")
 	if err != nil {
-		t.Fatal()
+		t.Fatalf("Failed to read test data: %v", err)
 		return
 	}
 
 	var event Event
 	if err = json.Unmarshal(b, &event); err != nil {
-		t.Fatal()
+		t.Fatalf("Failed to unmarshal event data: %v", err)
 		return
 	}
 
@@ -95,13 +95,13 @@ func TestUpdateEvent(t *testing.T) {
 
 	b, err := ioutil.ReadFile("testdata/event.json")
 	if err != nil {
-		t.Fatal()
+		t.Fatalf("Failed to read test data: %v", err)
 		return
 	}
 
 	var event Event
 	if err = json.Unmarshal(b, &event); err != nil {
-		t.Fatal()
+		t.Fatalf("Failed to unmarshal event data: %v", err)
 		return
 	}
 
@@ -126,7 +126,7 @@ func TestDeleteEvent(t *testing.T) {
 
 	c, err := NewClient("subdomain", "user", "password")
 
-	if err = c.DeleteEvent("123"); err != nil {
+	if err = c.DeleteEvent(123); err != nil {
 		t.Errorf("Expected success, but error: %s", err)
 		return
 	}

--- a/facility.go
+++ b/facility.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Facility struct {
-	ID            string `json:"id,omitempty"`
+	ID            int64  `json:"id,string,omitempty"`
 	Name          string `json:"name,omitempty"`
 	Code          string `json:"code,omitempty"`
 	Notes         string `json:"notes,omitempty"`
@@ -15,13 +15,13 @@ type Facility struct {
 }
 
 type FacilityGroup struct {
-	ID                  string `json:"id"`
+	ID                  int64  `json:"id,string"`
 	Name                string `json:"name"`
 	Code                string `json:"code"`
 	Notes               string `json:"notes"`
 	ParentFacilityGroup string `json:"parentFacilityGroup"`
 	ChildFacilityGroups []struct {
-		ID string `json:"id"`
+		ID int64 `json:"id,string"`
 	} `json:"childFacilityGroups"`
 }
 
@@ -65,8 +65,8 @@ func (c *Client) GetFacilityGroups(values url.Values) (*FacilityGroupPager, erro
 	return &pager, nil
 }
 
-func (c *Client) GetFacilitiesByFacilityGroup(facilityGroupID string, values url.Values) (*FacilityPager, error) {
-	path := fmt.Sprintf("schedule/facilityGroups/%s/facilities?%s", facilityGroupID, values.Encode())
+func (c *Client) GetFacilitiesByFacilityGroup(facilityGroupID int64, values url.Values) (*FacilityPager, error) {
+	path := fmt.Sprintf("schedule/facilityGroups/%d/facilities?%s", facilityGroupID, values.Encode())
 	var pager FacilityPager
 	if err := c.fetchResource("GET", path, nil, &pager); err != nil {
 		return nil, err

--- a/facility_test.go
+++ b/facility_test.go
@@ -73,7 +73,7 @@ func TestGetFacilitiesByFacilityGroup(t *testing.T) {
 
 	v := url.Values{}
 
-	_, err = c.GetFacilitiesByFacilityGroup("1", v)
+	_, err = c.GetFacilitiesByFacilityGroup(1, v)
 	if err != nil {
 		t.Errorf("Expected success, but error: %s", err)
 		return

--- a/notification_item_test.go
+++ b/notification_item_test.go
@@ -14,7 +14,7 @@ func TestGetNotificationItems(t *testing.T) {
 
 	b, err := ioutil.ReadFile("testdata/notification_items.json")
 	if err != nil {
-		t.Fatal()
+		t.Fatalf("Failed to read test data: %v", err)
 		return
 	}
 

--- a/organization.go
+++ b/organization.go
@@ -6,12 +6,12 @@ import (
 )
 
 type Organization struct {
-	ID                 string `json:"id"`
+	ID                 int64  `json:"id,string"`
 	Name               string `json:"name"`
 	Code               string `json:"code"`
 	ParentOrganization string `json:"parentOrganization"`
 	ChildOrganizations []struct {
-		ID string `json:"id"`
+		ID int64 `json:"id,string"`
 	} `json:"childOrganizations"`
 }
 

--- a/organization_test.go
+++ b/organization_test.go
@@ -14,7 +14,7 @@ func TestGetOrganizations(t *testing.T) {
 
 	b, err := ioutil.ReadFile("testdata/organizations.json")
 	if err != nil {
-		t.Fatal()
+		t.Fatalf("Failed to read test data: %v", err)
 		return
 	}
 

--- a/user.go
+++ b/user.go
@@ -6,7 +6,7 @@ import (
 )
 
 type User struct {
-	ID   string `json:"id,omitempty"`
+	ID   int64  `json:"id,string,omitempty"`
 	Code string `json:"code,omitempty"`
 	Name string `json:"name,omitempty"`
 	Type string `json:"type"`
@@ -35,8 +35,8 @@ func (c *Client) SearchUsers(values url.Values) (*UserPager, error) {
 	return &pager, nil
 }
 
-func (c *Client) GetUsersByOrganization(organizationID string, values url.Values) (*UserPager, error) {
-	path := fmt.Sprintf("base/organizations/%s/users?%s", organizationID, values.Encode())
+func (c *Client) GetUsersByOrganization(organizationID int64, values url.Values) (*UserPager, error) {
+	path := fmt.Sprintf("base/organizations/%d/users?%s", organizationID, values.Encode())
 	var pager UserPager
 	if err := c.fetchResource("GET", path, nil, &pager); err != nil {
 		return nil, err

--- a/user_test.go
+++ b/user_test.go
@@ -14,7 +14,7 @@ func TestSearchUsers(t *testing.T) {
 
 	b, err := ioutil.ReadFile("testdata/users.json")
 	if err != nil {
-		t.Fatal()
+		t.Fatalf("Failed to read test data: %v", err)
 		return
 	}
 
@@ -38,7 +38,7 @@ func TestGetUsersByOrganization(t *testing.T) {
 
 	b, err := ioutil.ReadFile("testdata/users.json")
 	if err != nil {
-		t.Fatal()
+		t.Fatalf("Failed to read test data: %v", err)
 		return
 	}
 
@@ -49,7 +49,7 @@ func TestGetUsersByOrganization(t *testing.T) {
 
 	v := url.Values{}
 
-	_, err = c.GetUsersByOrganization("1", v)
+	_, err = c.GetUsersByOrganization(1, v)
 	if err != nil {
 		t.Errorf("Expected success, but error: %s", err)
 		return


### PR DESCRIPTION
I think it better to use int64 instead of string just for the validation of numerical input.